### PR TITLE
 Fix CMake typo in python module build type check on Apple

### DIFF
--- a/src/python_module/src/CMakeLists.txt
+++ b/src/python_module/src/CMakeLists.txt
@@ -37,7 +37,7 @@ if (APPLE)
 	# Note - for Apple we install into the vcpkg installation structure at build time.
 	# Our install commands will copy the entire python3.X folder into the app bundle
 	# when making the re-locatable .app structure
-	if (${CMAKE__BUILD_TYPE} STREQUAL "Debug")
+	if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 		set(OUTPUT_DIR "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib/${PYTHONVP}/site-packages/xstudio/core")
 	else()
 		set(OUTPUT_DIR "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/${PYTHONVP}/site-packages/xstudio/core")


### PR DESCRIPTION
### Summarize your change.

Corrected a typo in the CMake variable `CMAKE__BUILD_TYPE` to the correct `CMAKE_BUILD_TYPE` within the `src/python_module/src/CMakeLists.txt` file.

### Describe what you have tested and on which operating system.

Verified that it build successfully without the previously mentioned error after applying this change. Tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

-   **File:** `src/python_module/src/CMakeLists.txt`
    -   Changed `if (${CMAKE__BUILD_TYPE} STREQUAL "Debug")`
    -   To `if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")`

This is a straightforward typo correction and should not require special attention beyond verifying the variable name is now correct.